### PR TITLE
fix: middleware trying to send more than one requests bug: set header…

### DIFF
--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -37,8 +37,6 @@ const errorHandler = (
   }
 
   res.status(status).send(errorBody);
-
-  next();
 };
 
 export default errorHandler;

--- a/src/middlewares/request-validator.ts
+++ b/src/middlewares/request-validator.ts
@@ -13,7 +13,10 @@ export default class RequestValidator {
         const errors = await validate(
           convertedObject as Record<string, unknown>
         );
-        if (!errors.length) next();
+        if (!errors.length) {
+          next();
+          return;
+        }
         const rawErrors: string[] = [
           ...new Set([
             ...errors.flatMap((error) =>


### PR DESCRIPTION
fixed bug Error: Cannot set headers after they are sent to the client, since the middleware does not end after calling next(), so ensured only on response